### PR TITLE
Allow precision selection, fix trailing 0 removal

### DIFF
--- a/autoload/crunch.vim
+++ b/autoload/crunch.vim
@@ -655,15 +655,13 @@ function! s:vim_eval(expr) abort "{{{2
 
 "    Decho '== Evaluate Expression =='
 "    Decho '[' . a:expr . ']= the final expression'
-
-    let result = string(eval(a:expr))
+    let precision = str2nr(g:crunch_precision)
+    let result = printf("%.".precision."f",(eval(a:expr)))
 "    Decho '['.result.']= before trailing ".0" removed'
 "    Decho '['.matchstr(result,'\v\.0+$').']= trailing ".0"'
 
     "check for trailing '.0' in result and remove it (occurs with vim eval)
-    if result =~# '\v\.0+$'
-        let result = string(str2nr(result))
-    endif
+    let result = substitute(result, '\v\.=0+$', '', '')
 
     return result
 endfunction "}}}2

--- a/doc/crunch.txt
+++ b/doc/crunch.txt
@@ -34,6 +34,7 @@
          4.2 g:crunch_comment ....................... |crunch-comment|
          4.3 g:crunch_result_type_append ............ |crunch-result-type-append|
          4.4 g:crunch_user_variables ................ |crunch-user-variables|
+         4.5 g:crunch_precision ..................... |crunch-precision|
      5. Known Issues ................................ |crunch-known-issues|
      6. Contribute .................................. |crunch-contribute|
      7. Change Log .................................. |crunch-change-log|
@@ -294,7 +295,7 @@ see |crunch-comments|
 ------------------------------------------------------------------------------
 4.3 g:crunch_result_type_append                   *crunch-result-type-append*
 
-Defualt 1
+Default 1
 
 Controls whether or not the result of each expression(s) is appended to the 
 expression or if the result replaces the expression(s).
@@ -321,6 +322,17 @@ let g:crunch_user_variables = {'foo': 123,  'j':456}
 ALTERNATIVELY~
 
 let g:crunch_user_variables = {'e': exp(1),  'pi':3.14159265359}
+
+------------------------------------------------------------------------------
+4.5 g:crunch_precision                                     *crunch-precision*
+
+Default 6
+
+Controls the output precision of floating point numbers. Default is 6, to
+maintain the old behaviour of this plugin. Maximum precision depends on the
+precision of the floating point library used when compiling vim, see
+|floating-point-precision| for details. Trailing 0s are removed.
+
 
 ==============================================================================
 5. KNOWN ISSUES                                         *crunch-known-issues*

--- a/plugin/crunch.vim
+++ b/plugin/crunch.vim
@@ -21,6 +21,7 @@ let g:crunch_prompt = get(g:, 'crunch_prompt', 'Calc >> ')
 let g:crunch_comment = get(g:, 'crunch_comment', '"')
 let g:crunch_user_variables = get(g:, 'crunch_user_variables', {})
 let g:crunch_result_type_append = get(g:, 'crunch_result_type_append', 1)
+let g:crunch_precision = get(g:, 'crunch_precision', 6)
 let g:util_debug = get(g:, 'util_debug', 0)
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""}}}
 


### PR DESCRIPTION
Due to the use of string and str2nr, the precision of this plugin is 6 floating point digits. By using printf, arbitrary selectable precision is allowed. This does mean that trailing 0s *always* need to be stripped, and the stripping can't use `string(str2nr(result))`, because that would reset the precision to 6. So I've replaced the if-statement with a substitute that does the stripping.

Configure using g:crunch_precision, set by default to 6 to match the old behaviour.

Input validation on that variable is something I did not do -- setting it to something weird will result in no output being generated.